### PR TITLE
Avoid unecessary dependency on pytest-aiohttp module

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,7 +2,6 @@ aiohttp==3.1.2
 flake8==3.5.0
 pytest==3.5.0
 pytest-cov==2.5.1
-pytest-aiohttp==0.3.0
 pytest-mock==1.8.0
 tox==3.0.0
 isort==4.3.4

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,8 @@ from aiohttp import web
 
 from aiohttp_jwt import JWTMiddleware
 
+pytest_plugins = 'aiohttp.pytest_plugin'
+
 
 @pytest.fixture
 def fake_payload():


### PR DESCRIPTION
If you look at the pytest-aiohttp module you will see it contains no code, it is just a wrapper silently doing the single line of this PR ;-)