### PR TITLE
Make unittests compatible with aiohttp 2.x

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,11 @@ from aiohttp_jwt import JWTMiddleware
 
 
 @pytest.fixture
+def aiohttp_client(test_client):
+    return test_client
+
+
+@pytest.fixture
 def fake_payload():
     return {'foo': 'bar'}
 


### PR DESCRIPTION
Follow Up of https://github.com/hzlmn/aiohttp-jwt/issues/26
Confirmed it fixes the test run on my system