### PR TITLE
allow any whitespace to be used in auth header

### DIFF
--- a/aiohttp_jwt/middleware.py
+++ b/aiohttp_jwt/middleware.py
@@ -50,7 +50,7 @@ def JWTMiddleware(
             try:
                 scheme, token = request.headers.get(
                     'Authorization'
-                ).strip().split(' ')
+                ).split()
             except ValueError:
                 raise web.HTTPForbidden(
                     reason='Invalid authorization header',


### PR DESCRIPTION
According to RFC 7235 (https://tools.ietf.org/html/rfc7235#appendix-C) Authorization header definition allows multiple whitespaces to be used between scheme and token. Also, we derive a bit from the standard stripping the string (see `auth-scheme` definition), but for simplicity, I propose just splitting the header value. This should return the following:
```
>>> '  Bearer  123  '.split()
['Bearer', '123']
```